### PR TITLE
registry: add component componentize-qjs

### DIFF
--- a/registry/andreiltd.toml
+++ b/registry/andreiltd.toml
@@ -1,0 +1,19 @@
+[namespace]
+name = "andreiltd"
+registry = "ghcr.io/andreiltd"
+
+[[component]]
+name = "componentize-qjs-runtime"
+repository = "componentize-qjs/componentize-qjs-runtime"
+
+[[component]]
+name = "componentize-qjs-runtime-opt-size"
+repository = "componentize-qjs/componentize-qjs-runtime-opt-size"
+
+[[component]]
+name = "componentize-qjs-runtime-sync"
+repository = "componentize-qjs/componentize-qjs-runtime-sync"
+
+[[component]]
+name = "componentize-qjs-runtime-opt-size-sync"
+repository = "componentize-qjs/componentize-qjs-runtime-opt-size-sync"


### PR DESCRIPTION
The patch creates a new namespace: andreiltd and adds componentize-qjs components family.